### PR TITLE
bug fix to allow single-column "logos"

### DIFF
--- a/R/heights.r
+++ b/R/heights.r
@@ -133,7 +133,7 @@ makePFM <- function(seqs, seq_type='auto', namespace=NULL, keep_letter_mat=F){
       pfm_mat = rbind(pfm_mat, miss)
     }
     
-    pfm_mat = pfm_mat[namespace,]
+    pfm_mat = pfm_mat[namespace, , drop=FALSE]
 
   }else{
     # Process sequences


### PR DESCRIPTION
A matrix subset during PFM formation uses the default `drop` setting,
which converts the matrix to a vector. By setting `drop=FALSE` the
rest of the code works with a single column matrix.