### PR TITLE
Fixed ggplot2 `guides` deprecation warning

### DIFF
--- a/R/ggseqlogo.r
+++ b/R/ggseqlogo.r
@@ -214,7 +214,7 @@ geom_logo <- function(data = NULL, method='bits', seq_type='auto', namespace=NUL
   
   # If letters and group are the same, don't draw legend
   guides_opts = NULL
-  if(identical(cs$letter, cs$group)) guides_opts = guides(fill=F)
+  if(identical(cs$letter, cs$group)) guides_opts = guides(fill = "none")
   
   y_lim = NULL
   extra_opts = NULL


### PR DESCRIPTION
Fixes <scale>` argument of `guides()` cannot be `FALSE`. Use "none" instead as of ggplot2 3.3.4 and #28 Fixes Deprecated feature from ggplot2 3.3.4 used in ggseqlogo #32 

